### PR TITLE
Add 12.0 prerelease manifest updated via repository dispatch

### DIFF
--- a/.github/scripts/update-prerelease-manifest.js
+++ b/.github/scripts/update-prerelease-manifest.js
@@ -1,0 +1,131 @@
+// .github/scripts/update-prerelease-manifest.js
+//
+// Handles the "update-prerelease-manifest" repository dispatch sent by the
+// intro-skipper build workflow after every commit. Unlike stable releases,
+// prerelease builds are published to manifest-prerelease.json and the
+// catalog only ever contains the single most recent build, because the
+// rolling prerelease GitHub release is replaced on every commit.
+const fs = require("fs");
+const path = require("path");
+
+const clientPayloadJson = process.env.CLIENT_PAYLOAD_JSON;
+
+if (!clientPayloadJson) {
+  console.error(
+    "Error: CLIENT_PAYLOAD_JSON environment variable is not set.",
+  );
+  process.exit(1);
+}
+
+let payload;
+try {
+  payload = JSON.parse(clientPayloadJson);
+  console.log("Parsed CLIENT_PAYLOAD_JSON successfully.");
+  console.log("Payload content:", payload);
+} catch (e) {
+  console.error("Error: Could not parse CLIENT_PAYLOAD_JSON.", e);
+  process.exit(1);
+}
+
+// --- Extract data from payload ---
+const pluginNameToUpdate = payload.pluginName;
+console.log(`Plugin to update: ${pluginNameToUpdate}`);
+const newVersionEntry = {
+  version: payload.version,
+  changelog: payload.changelog,
+  targetAbi: payload.targetAbi,
+  sourceUrl: payload.sourceUrl,
+  checksum: payload.checksum,
+  timestamp: payload.timestamp,
+};
+
+if (!pluginNameToUpdate || typeof pluginNameToUpdate !== "string") {
+  console.error("Error: 'pluginName' field is missing or not a string in the client_payload.");
+  process.exit(1);
+}
+if (!newVersionEntry.version || typeof newVersionEntry.version !== "string") {
+  console.error("Error: 'version' (for the new plugin entry) is missing or not a string in the client_payload.");
+  process.exit(1);
+}
+
+// --- Determine catalog directory from the targetAbi (same as update-manifest.js) ---
+const catalogVersionSource = newVersionEntry.targetAbi;
+
+let catalogDirName = newVersionEntry.version.split(".").slice(0, 2).join(".");
+
+if (typeof catalogVersionSource === "string") {
+  try {
+    const parts = catalogVersionSource.split(".");
+    if (parts.length >= 2) {
+      const extractedPrefix = parts.slice(0, 2).join(".");
+      if (/^\d+\.\d+$/.test(extractedPrefix)) {
+        catalogDirName = extractedPrefix;
+        console.log(`Using extracted prefix "${extractedPrefix}" from new version's targetAbi ("${catalogVersionSource}") for catalog directory.`);
+      } else {
+        console.warn(`Could not extract a valid 'major.minor' prefix from new version's targetAbi "${catalogVersionSource}". Using default "${catalogDirName}".`);
+      }
+    } else {
+      console.warn(`New version's targetAbi "${catalogVersionSource}" does not have enough parts. Using default "${catalogDirName}".`);
+    }
+  } catch (e) {
+    console.warn(`Error processing new version's targetAbi: ${e.message}. Using default "${catalogDirName}".`);
+  }
+} else {
+  console.log(`New version's targetAbi is not a string. Using default "${catalogDirName}" for catalog directory.`);
+}
+
+const catalogFilePath = path.join(catalogDirName, "manifest-prerelease.json");
+
+try {
+  if (!fs.existsSync(catalogDirName)) {
+    console.error(`Error: Catalog directory "${catalogDirName}" does not exist. Cannot add version to non-existent catalog.`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(catalogFilePath)) {
+    console.error(`Error: Catalog file ${catalogFilePath} does not exist. Cannot update a non-existent prerelease catalog.`);
+    process.exit(1);
+  }
+
+  console.log(`Reading existing catalog file: ${catalogFilePath}`);
+  const fileContent = fs.readFileSync(catalogFilePath, "utf-8");
+  let catalogData;
+  try {
+    catalogData = JSON.parse(fileContent);
+    if (!Array.isArray(catalogData)) {
+      console.error(`Error: Content of ${catalogFilePath} is not a JSON array. Cannot process.`);
+      process.exit(1);
+    }
+  } catch (e) {
+    console.error(`Error: Could not parse JSON from ${catalogFilePath}. Error: ${e.message}`);
+    process.exit(1);
+  }
+
+  // Find the plugin to update within the catalog
+  const pluginIndex = catalogData.findIndex(
+    (p) => p.name === pluginNameToUpdate,
+  );
+
+  if (pluginIndex === -1) {
+    console.error(`Error: Plugin "${pluginNameToUpdate}" not found in catalog file "${catalogFilePath}". Cannot add new version.`);
+    process.exit(1);
+  }
+
+  // The prerelease catalog only keeps the single most recent build, since
+  // the rolling prerelease release only hosts the newest archive.
+  catalogData[pluginIndex].versions = [newVersionEntry];
+  console.log(`Set version ${newVersionEntry.version} as the only prerelease entry for plugin "${pluginNameToUpdate}".`);
+
+  fs.writeFileSync(catalogFilePath, JSON.stringify(catalogData, null, 4) + "\n");
+
+  console.log(`Successfully updated catalog file: ${catalogFilePath}`);
+  const updatedPluginForLog = catalogData.find(p => p.name === pluginNameToUpdate);
+  console.log("--- Updated Plugin Entry ---");
+  console.log(JSON.stringify(updatedPluginForLog, null, 2));
+  console.log("----------------------------");
+
+  process.exit(0);
+} catch (error) {
+  console.error(`Error processing catalog file ${catalogFilePath}:`, error);
+  process.exit(1);
+}

--- a/.github/scripts/validate-json.py
+++ b/.github/scripts/validate-json.py
@@ -1,7 +1,8 @@
 """Validate JSON files and Jellyfin plugin manifests.
 
 Every ``*.json`` file under the repository root is parsed for syntax. Files
-named ``manifest.json`` are additionally validated against the shape
+named ``manifest.json`` or ``manifest-prerelease.json`` are additionally
+validated against the shape
 Jellyfin 10.11's ``InstallationManager`` expects when deserialising and
 using ``PackageInfo`` / ``VersionInfo`` (see
 ``Emby.Server.Implementations/Updates/InstallationManager.cs`` on the
@@ -226,7 +227,7 @@ def _validate_manifest(data: Any, errors: list[str]) -> None:
 
 
 def _is_manifest_file(path: pathlib.Path) -> bool:
-    return path.name == "manifest.json"
+    return path.name in ("manifest.json", "manifest-prerelease.json")
 
 
 def main() -> int:

--- a/.github/workflows/update-prerelease-manifest.yml
+++ b/.github/workflows/update-prerelease-manifest.yml
@@ -1,0 +1,69 @@
+name: Update Prerelease Manifest on Dispatch
+
+on:
+  repository_dispatch:
+    types: [update-prerelease-manifest]
+
+# Prerelease dispatches arrive on every commit to a release branch. Serialize
+# the runs and let a newer pending run replace an older pending one, since
+# every run rewrites the complete prerelease entry anyway.
+concurrency:
+  group: update-prerelease-manifest
+  cancel-in-progress: false
+
+jobs:
+  update_prerelease_manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Update manifest-prerelease.json using Node.js script
+        run: |
+          node .github/scripts/update-prerelease-manifest.js
+        env:
+          CLIENT_PAYLOAD_JSON: ${{ toJSON(github.event.client_payload) }}
+
+      - name: Validate JSON files
+        run: python .github/scripts/validate-json.py
+
+      - name: Commit and push
+        if: success()
+        env:
+          PLUGIN_NAME: ${{ github.event.client_payload.pluginName }}
+          PLUGIN_VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add '*manifest-prerelease.json'
+
+          if git diff --staged --quiet; then
+            echo "No changes staged for commit. Working tree clean or no changes to specified file."
+            exit 0
+          fi
+
+          git commit -m "chore: update ${PLUGIN_NAME} prerelease to v${PLUGIN_VERSION}"
+
+          # Dispatches can arrive in quick succession; rebase and retry if
+          # another run pushed between our checkout and push.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}), rebasing onto latest main..."
+            git pull --rebase origin main
+          done
+
+          echo "Failed to push after 3 attempts."
+          exit 1

--- a/12.0/manifest-prerelease.json
+++ b/12.0/manifest-prerelease.json
@@ -1,0 +1,12 @@
+[
+    {
+        "guid": "c83d86bb-a1e0-4c35-a113-e2101cf4ee6b",
+        "name": "Intro Skipper",
+        "overview": "Automatically detect and skip intros in television episodes (prerelease builds)",
+        "description": "Analyzes the audio of television episodes and detects introduction sequences. This catalog contains the automatically published prerelease build of the latest commit and is replaced on every commit.",
+        "owner": "AbandonedCart, rlauuzo, jumoog (forked from ConfusedPolarBear)",
+        "category": "MoviesAndShows",
+        "imageUrl": "https://cdn.jsdelivr.net/gh/intro-skipper/manifest@a434e00edba70493794e25917cc8d3326d5a85c6/images/intro-skipper/logo.png",
+        "versions": []
+    }
+]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 https://intro-skipper.org/manifest.json
 ```
 
+## Prerelease Manifest URL (Jellyfin 12.0)
+
+Every commit to the intro-skipper `12.0` branch publishes an automated prerelease build to `12.0/manifest-prerelease.json`. Add this URL as an additional repository in Jellyfin to test the latest build:
+
+```
+https://raw.githubusercontent.com/intro-skipper/manifest/main/12.0/manifest-prerelease.json
+```
+
+Prerelease versions follow the scheme `<jellyfin major>.<jellyfin minor>.<release>.<commits since release>` (for example `12.0.1.14`), so a prerelease always sorts above the stable release it is based on and below the next stable release. The catalog only contains the single most recent build, as each build replaces the previous prerelease archive.
+
 # Issues
 
 If you are having issues, check this out:


### PR DESCRIPTION
## Summary

Companion to intro-skipper/intro-skipper#845 (new `<jellyfin major>.<jellyfin minor>.<release>.<prerelease>` version scheme). Adds a prerelease catalog for the 12.0 branch that receives an automated entry for every commit built on that branch.

## Changes

- **`12.0/manifest-prerelease.json`**: new catalog seeded with the Intro Skipper package (same GUID as stable, so installs upgrade each other) and an empty `versions` array. The first dispatch after the intro-skipper PR merges populates it.
- **`.github/workflows/update-prerelease-manifest.yml`**: handles the `update-prerelease-manifest` repository dispatch sent by the intro-skipper build workflow. Runs the update script, validates JSON, and commits directly to `main` (per-commit PRs would spam; direct push matches the existing `update-plugins.yml` behavior). Runs are serialized via a concurrency group with last-pending-wins, plus a rebase-and-retry push loop for dispatches arriving in quick succession.
- **`.github/scripts/update-prerelease-manifest.js`**: mirrors `update-manifest.js` (catalog dir derived from `targetAbi`), but **replaces** the plugin's `versions` array with the single new entry instead of prepending — the rolling `12.0/prerelease` GitHub release only hosts the newest archive, so older entries would be dead links.
- **`validate-json.py`**: `manifest-prerelease.json` files now get the same deep `PackageInfo`/`VersionInfo` validation as `manifest.json` (this matters more here than for stable: prerelease entries land without human review).
- **`README.md`**: documents the prerelease catalog URL (`raw.githubusercontent.com`, which has short cache TTL — jsDelivr's ~12h `@main` cache would defeat per-commit updates) and the version scheme. The `intro-skipper.org` UA-routing worker can grow a prerelease endpoint later; that infra lives outside this repo.

`check-plugins.js` (daily job) only reads/writes files literally named `manifest.json`, so it never touches the prerelease catalog.

## Verified

- Update script run end-to-end with a real payload from the new build workflow logic: entry written with 4-space indent, second dispatch replaces (not appends) the entry.
- `validate-json.py` passes on the seeded file and deep-validates the populated one.
- `git add '*manifest-prerelease.json'` pathspec confirmed to stage the file.

Merge this before intro-skipper/intro-skipper#845 so dispatches have a target.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/9de5844c-5ff6-4827-bb95-7d61e787a3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-097" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/9de5844c-5ff6-4827-bb95-7d61e787a3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-097&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-097"><img alt="INTRO-097" src="https://capy.ai/api/badge/thread.svg?label=INTRO-097"></picture></a>
<!-- capy-pr-badge:end -->